### PR TITLE
Fix Acknowledgements link in English pages

### DIFF
--- a/content/bibliography.md
+++ b/content/bibliography.md
@@ -17,7 +17,7 @@ github:
 
 footer: > # Text in footer in HTML
   <p><strong>Date:</strong> <strong>Published 9 Nov 2018.</strong></p>
-  <p><strong>Editor:</strong> Sharron Rush. Contributors: Shawn Lawton Henry, Eric Eggert, Brent Bakken, Vicki Menezes Miller, Laura Keen. <a href="./acknowledgements/">Acknowledgements</a> lists additional contributors.</p>
+  <p><strong>Editor:</strong> Sharron Rush. Contributors: Shawn Lawton Henry, Eric Eggert, Brent Bakken, Vicki Menezes Miller, Laura Keen. <a href="/WAI/business-case/acknowledgements/">Acknowledgements</a> lists additional contributors.</p>
   <p>Developed by the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>).</p>
 image: /content-images/wai-bcase/social.png
 ref: /business-case/bibliography/

--- a/content/bibliography.md
+++ b/content/bibliography.md
@@ -17,7 +17,7 @@ github:
 
 footer: > # Text in footer in HTML
   <p><strong>Date:</strong> <strong>Published 9 Nov 2018.</strong></p>
-  <p><strong>Editor:</strong> Sharron Rush. Contributors: Shawn Lawton Henry, Eric Eggert, Brent Bakken, Vicki Menezes Miller, Laura Keen. <a href="/WAI/business-case/acknowledgements/">Acknowledgements</a> lists additional contributors.</p>
+  <p><strong>Editor:</strong> Sharron Rush. Contributors: Shawn Lawton Henry, Eric Eggert, Brent Bakken, Vicki Menezes Miller, Laura Keen. <a href="/business-case/acknowledgements/">Acknowledgements</a> lists additional contributors.</p>
   <p>Developed by the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>).</p>
 image: /content-images/wai-bcase/social.png
 ref: /business-case/bibliography/

--- a/content/index.md
+++ b/content/index.md
@@ -16,7 +16,7 @@ github:
 
 footer: > # Text in footer in HTML
   <p><strong>Date:</strong> Published 9 Nov 2018.</p>
-  <p><strong>Editor:</strong> Sharron Rush. Contributors: Shawn Lawton Henry, Eric Eggert, Brent Bakken, Vicki Menezes Miller, Laura Keen. <a href="./acknowledgements/">Acknowledgements</a> lists additional contributors.</p>
+  <p><strong>Editor:</strong> Sharron Rush. Contributors: Shawn Lawton Henry, Eric Eggert, Brent Bakken, Vicki Menezes Miller, Laura Keen. <a href="/WAI/business-case/acknowledgements/">Acknowledgements</a> lists additional contributors.</p>
   <p>Developed by the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>).</p>
 inline_css: |
   .hero {

--- a/content/index.md
+++ b/content/index.md
@@ -16,7 +16,7 @@ github:
 
 footer: > # Text in footer in HTML
   <p><strong>Date:</strong> Published 9 Nov 2018.</p>
-  <p><strong>Editor:</strong> Sharron Rush. Contributors: Shawn Lawton Henry, Eric Eggert, Brent Bakken, Vicki Menezes Miller, Laura Keen. <a href="/WAI/business-case/acknowledgements/">Acknowledgements</a> lists additional contributors.</p>
+  <p><strong>Editor:</strong> Sharron Rush. Contributors: Shawn Lawton Henry, Eric Eggert, Brent Bakken, Vicki Menezes Miller, Laura Keen. <a href="/business-case/acknowledgements/">Acknowledgements</a> lists additional contributors.</p>
   <p>Developed by the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>).</p>
 inline_css: |
   .hero {


### PR DESCRIPTION
- Acknowledgements link is not working on the [Bibliography page](https://www.w3.org/WAI/business-case/bibliography/).
- It is working in the [Business case page](https://www.w3.org/WAI/business-case/), but I apply the modified one here for consistency.